### PR TITLE
Remove step level output type declaration

### DIFF
--- a/porter.yaml
+++ b/porter.yaml
@@ -53,7 +53,6 @@ install:
       outputs:
         - name: random_string
           regex: "(.*)"
-          type: string
   - az:
       description: "Creating the KeyVault..."
       suppress-output: true
@@ -68,7 +67,6 @@ install:
       outputs:
         - name: "keyvault_name"
           jsonPath: "$.name"
-          type: string
 
 upgrade:
   - exec:


### PR DESCRIPTION
Type is only applicable on the bundle level outputs defined at the end of the manifest, and on parameters. Step level outputs (defined on a step in an action) do not have a type field.

This doesn't impact the bundle from running properly, but the fields aren't necessary and are completely ignored so you may as well remove them. 😀 